### PR TITLE
Allow definition of VARNISH_PORT

### DIFF
--- a/4.1/start-varnishd.sh
+++ b/4.1/start-varnishd.sh
@@ -3,7 +3,7 @@ set -e
 
 exec bash -c \
 	"exec varnishd -j unix,user=varnish -F \
-	-a :6081 \
+	-a :${VARNISH_PORT:-6081} \
 	-f ${VCL_CONFIG} \
 	-s malloc,${VARNISH_MEMORY} \
 	${VARNISHD_PARAMS}"

--- a/5.0/start-varnishd.sh
+++ b/5.0/start-varnishd.sh
@@ -3,7 +3,7 @@ set -e
 
 exec bash -c \
 	"exec varnishd -j unix,user=varnish -F \
-	-a :6081 \
+	-a :${VARNISH_PORT:-6081} \
 	-f ${VCL_CONFIG} \
 	-s malloc,${VARNISH_MEMORY} \
 	${VARNISHD_PARAMS}"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ You can change the path of the VCL configuration file:
 $ docker run --name my-running-varnish -e "VCL_CONFIG=/root/custom.vcl" -v /path/to/custom.vcl:/root/custom.vcl:ro -d my-varnish
 ```
 
+You can also change the ports used in a Dockerfile.
+
+```
+FROM tripviss/varnish
+
+ENV VARNISH_PORT 8080
+ENV VARNISHD_PARAMS "additional varnish options here"
+EXPOSE 8080
+```
+
+Or with a command:
+
+```console
+$ docker run --name my-running-varnish -e "VARNISH_PORT=80" -d -p 80:80 my-varnish
+```
+
 # How to install VMODs (Varnish Modules)
 
 [Varnish Modules](https://www.varnish-cache.org/vmods) are extensions written for Varnish Cache.


### PR DESCRIPTION
I need to use a different port from 6081 (similar to the issue mentioned in https://github.com/newsdev/docker-varnish/pull/2#issuecomment-250178825) . This defines a default port, but also let's users specify $VARNISH_PORT. They'll still need to expose it themselves.