### PR TITLE
Run as non-root to support Openshift

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -23,9 +23,6 @@ RUN \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN \
-	adduser --quiet --system --no-create-home --group varnish
-
 ENV VARNISH_VERSION 4.1.6
 ENV VARNISH_FILENAME varnish-4.1.6.tar.gz
 ENV VARNISH_SHA256 c7ac460b521bebf772868b2f5aefc2f2508a1e133809cd52d3ba1b312226e849
@@ -45,9 +42,14 @@ RUN set -xe \
 
 COPY start-varnishd.sh /usr/local/bin/start-varnishd
 
+RUN mkdir /varnishfs \
+        && chgrp -R 0 /varnishfs \
+        && chmod -R g+rwX /varnishfs
+
 ENV VCL_CONFIG /etc/varnish/default.vcl
 ENV VARNISH_MEMORY 100m
 
 EXPOSE 6081
+USER 1001
 
 CMD ["start-varnishd"]

--- a/4.1/start-varnishd.sh
+++ b/4.1/start-varnishd.sh
@@ -2,7 +2,7 @@
 set -e
 
 exec bash -c \
-	"exec varnishd -j unix,user=varnish -F \
+	"exec varnishd -n /varnishfs -F \
 	-a :${VARNISH_PORT:-6081} \
 	-f ${VCL_CONFIG} \
 	-s malloc,${VARNISH_MEMORY} \

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -23,9 +23,6 @@ RUN \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN \
-	adduser --quiet --system --no-create-home --group varnish
-
 ENV VARNISH_VERSION 5.0.0
 ENV VARNISH_FILENAME varnish-5.0.0.tar.gz
 ENV VARNISH_SHA256 5101ad72b29d288a07e2e5ded4c2abe850b70ff000c13ceb1764625e83823f4a
@@ -45,9 +42,14 @@ RUN set -xe \
 
 COPY start-varnishd.sh /usr/local/bin/start-varnishd
 
+RUN mkdir /varnishfs \
+        && chgrp -R 0 /varnishfs \
+        && chmod -R g+rwX /varnishfs
+
 ENV VCL_CONFIG /etc/varnish/default.vcl
 ENV VARNISH_MEMORY 100m
 
 EXPOSE 6081
+USER 1001
 
 CMD ["start-varnishd"]

--- a/5.0/start-varnishd.sh
+++ b/5.0/start-varnishd.sh
@@ -2,7 +2,7 @@
 set -e
 
 exec bash -c \
-	"exec varnishd -j unix,user=varnish -F \
+	"exec varnishd -n /varnishfs -F \
 	-a :${VARNISH_PORT:-6081} \
 	-f ${VCL_CONFIG} \
 	-s malloc,${VARNISH_MEMORY} \

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -23,9 +23,6 @@ RUN \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN \
-	adduser --quiet --system --no-create-home --group varnish
-
 ENV VARNISH_VERSION 5.1.2
 ENV VARNISH_FILENAME varnish-5.1.2.tar.gz
 ENV VARNISH_SHA256 39d858137e26948a7c85f07363f13f0778da61d234126e03a160a0cb9ba4fce3
@@ -45,9 +42,14 @@ RUN set -xe \
 
 COPY start-varnishd.sh /usr/local/bin/start-varnishd
 
+RUN mkdir /varnishfs \
+        && chgrp -R 0 /varnishfs \
+        && chmod -R g+rwX /varnishfs
+
 ENV VCL_CONFIG /etc/varnish/default.vcl
 ENV VARNISH_MEMORY 100m
 
 EXPOSE 6081
+USER 1001
 
 CMD ["start-varnishd"]

--- a/5.1/start-varnishd.sh
+++ b/5.1/start-varnishd.sh
@@ -2,7 +2,7 @@
 set -e
 
 exec bash -c \
-	"exec varnishd -j unix,user=varnish -F \
+	"exec varnishd -n /varnishfs -F \
 	-a :${VARNISH_PORT:-6081} \
 	-f ${VCL_CONFIG} \
 	-s malloc,${VARNISH_MEMORY} \


### PR DESCRIPTION
To run varnish inside Openshift the container needs to support running with an arbitrary user id, to acomplish this we removed the jail of varnish and changed the user of the container to a non root uid. The /varnishfs directory also allow us to mount a volume in that directory to interact with varnish from outside of the container, for example to extract metrics for prometheus.

What do you think about merging this?

To add vmods we need to switch to root before we can write to the filesystem, example:

```
FROM tripviss/varnish:5.1

USER 0

# Install Querystring Varnish module
ENV QUERYSTRING_VERSION 1.0.1
ENV QUERYSTRING_FILENAME libvmod-querystring-1.0.1.tar.gz
RUN \
  curl -fSL "https://github.com/Dridi/libvmod-querystring/archive/v$QUERYSTRING_VERSION.tar.gz" -o "$QUERYSTRING_FILENAME" \
  && tar -xzf "$QUERYSTRING_FILENAME" -C /usr/local/src \
  && mv "/usr/local/src/libvmod-querystring-$QUERYSTRING_VERSION" /usr/local/src/libvmod-querystring \
  && rm "$QUERYSTRING_FILENAME" \
  && cd /usr/local/src/libvmod-querystring \
  && ./autogen.sh \
  && ./configure VARNISHSRC=/usr/local/src/varnish \
  && make install

USER 1001
```
