### PR TITLE
Add explicit "--build" to our "./configure" invocations

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -5,6 +5,7 @@ RUN \
 	apt-get update && apt-get install -y --no-install-recommends \
 		automake \
 		build-essential \
+		dpkg-dev \
 		libedit-dev \
 		libjemalloc-dev \
 		libncurses-dev \
@@ -39,7 +40,10 @@ RUN set -xe \
 	&& rm "$VARNISH_FILENAME" \
 	&& cd /usr/local/src/varnish \
 	&& ./autogen.sh \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig
 

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -5,6 +5,7 @@ RUN \
 	apt-get update && apt-get install -y --no-install-recommends \
 		automake \
 		build-essential \
+		dpkg-dev \
 		libedit-dev \
 		libjemalloc-dev \
 		libncurses-dev \
@@ -39,7 +40,10 @@ RUN set -xe \
 	&& rm "$VARNISH_FILENAME" \
 	&& cd /usr/local/src/varnish \
 	&& ./autogen.sh \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig
 

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -5,6 +5,7 @@ RUN \
 	apt-get update && apt-get install -y --no-install-recommends \
 		automake \
 		build-essential \
+		dpkg-dev \
 		libedit-dev \
 		libjemalloc-dev \
 		libncurses-dev \
@@ -39,7 +40,10 @@ RUN set -xe \
 	&& rm "$VARNISH_FILENAME" \
 	&& cd /usr/local/src/varnish \
 	&& ./autogen.sh \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& ldconfig
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Supported tags and respective `Dockerfile` links
 
 - [`5.1.2`, `5.1`, `5`, `latest` (*5.1/Dockerfile*)](https://github.com/tripviss/docker-varnish/blob/master/5.1/Dockerfile)
-- [`5.0.0`, `5.0` (*5.0/Dockerfile*)](https://github.com/tripviss/docker-varnish/blob/master/5.0/Dockerfile)
 - [`4.1.6`, `4.1`, `4` (*4.1/Dockerfile*)](https://github.com/tripviss/docker-varnish/blob/master/4.1/Dockerfile)
 
 # What is Varnish?


### PR DESCRIPTION
Following @tianon's footsteps.

This is along the same lines as:

- docker-library/gcc#34
- docker-library/httpd#51
- jessfraz/irssi#14
- docker-library/php#429
- docker-library/postgres#284
- docker-library/python#198
- docker-library/ruby#127
- docker-library/tomcat#70
- tianon/docker-bash#3
- docker-library/memcached#13